### PR TITLE
emscripten  1.38.20-1

### DIFF
--- a/emcc/0001-Check-for-LLVM-env-to-set-llvm_root-on-initial-start.patch
+++ b/emcc/0001-Check-for-LLVM-env-to-set-llvm_root-on-initial-start.patch
@@ -11,15 +11,15 @@ diff --git a/tools/shared.py b/tools/shared.py
 index 2e5381b..75c9817 100644
 --- a/tools/shared.py
 +++ b/tools/shared.py
-@@ -224,7 +224,7 @@ else:
-     config_file = '\n'.join(config_file)
-     # autodetect some default paths
-     config_file = config_file.replace('\'{{{ EMSCRIPTEN_ROOT }}}\'', repr(__rootpath__))
--    llvm_root = os.path.dirname(find_executable('llvm-dis') or '/usr/bin/llvm-dis')
-+    llvm_root = os.environ.get('LLVM') or os.path.dirname(find_executable('llvm-dis') or '/usr/bin/llvm-dis')
-     config_file = config_file.replace('\'{{{ LLVM_ROOT }}}\'', repr(llvm_root))
-     binaryen_root = os.path.dirname(find_executable('asm2wasm') or '') # if we don't find it, we'll use the port
-     config_file = config_file.replace('\'{{{ BINARYEN_ROOT }}}\'', repr(binaryen_root))
+@@ -183,7 +183,7 @@
+   config_file = '\n'.join(config_file)
+   # autodetect some default paths
+   config_file = config_file.replace('\'{{{ EMSCRIPTEN_ROOT }}}\'', repr(__rootpath__))
+-  llvm_root = os.path.dirname(find_executable('llvm-dis') or '/usr/bin/llvm-dis')
++  llvm_root = os.environ.get('LLVM') or os.path.dirname(find_executable('llvm-dis') or '/usr/bin/llvm-dis')
+   config_file = config_file.replace('\'{{{ LLVM_ROOT }}}\'', repr(llvm_root))
+ 
+   node = find_executable('nodejs') or find_executable('node') or 'node'
 -- 
 2.9.3
 

--- a/emcc/emscripten.spec
+++ b/emcc/emscripten.spec
@@ -1,12 +1,12 @@
 Name: emscripten
-Version: 1.37.2
+Version: 1.38.20
 Release: 4%{?dist}
 Summary: The emscripten compiler.
 
 License: NCSA
 URL: https://github.com/kripken/emscripten
 
-#https://github.com/kripken/emscripten/archive/1.37.2.tar.gz
+#https://github.com/kripken/emscripten/archive/1.38.20.tar.gz
 Source0: %{name}-%{version}.tar.gz
 Source100: em.sh
 BuildArch: noarch

--- a/emscripten-fastcomp/emscripten-fastcomp.spec
+++ b/emscripten-fastcomp/emscripten-fastcomp.spec
@@ -1,7 +1,7 @@
 # We need to install it all in its own prefix.
 %define _prefix /usr/lib/emscripten
 Name: emscripten-fastcomp
-Version: 1.37.2
+Version: 1.38.20
 Release: 2%{?dist}
 Summary: The clang+llvm backend for Emscripten
 
@@ -71,8 +71,15 @@ rm -vf %{buildroot}%{_datadir}/clang/clang-format-bbedit.applescript
 rm -vf %{buildroot}%{_datadir}/clang/clang-format-sublime.py*
 rm -vf %{buildroot}%{_datadir}/clang/clang-format.el
 rm -vf %{buildroot}%{_datadir}/clang/clang-format.py*
+# remove renamer
+rm -vf %{buildroot}%{_datadir}/clang/clang-rename.el
+rm -vf %{buildroot}%{_datadir}/clang/clang-rename.py*
 # remove diff reformatter
 rm -vf %{buildroot}%{_datadir}/clang/clang-format-diff.py*
+# remove bash autocompleter
+rm -vf %{buildroot}%{_datadir}/clang/bash-autocomplete.sh
+# remove opt-viewer
+rm -vrf %{buildroot}%{_datadir}/opt-viewer/
 
 %post -p /sbin/ldconfig
 %postun -p /sbin/ldconfig


### PR DESCRIPTION
Hi, please consider the following change,

Let us upgrade to Emscripten 1.38.20, which upgrades to Binaryen 55,
thus allowing us to create WASM binaries tagged with "01" (release)
instead of "0d" (beta-d).

Signed-off-by: Tarnyko <tarnyko@tarnyko.net>